### PR TITLE
Napaka kodiranja datotek pri nalaganju v Windows okolju

### DIFF
--- a/tests/svm-test.py
+++ b/tests/svm-test.py
@@ -31,7 +31,7 @@ def get_text_data(origin="text-data"):
     for i, d in enumerate(dirs):
         files = glob.glob(d + "/*")
         for file_name in files:
-            with open(file_name, "rt") as file:
+            with open(file_name, "rt", encoding="utf8") as file:
                 X.append(" ".join(file.readlines()))
         y.extend([i] * len(files))
     return np.array(X), np.array(y)


### PR DESCRIPTION
V Windows okolju sem pri zagonu testov prejel sledečo napako:
UnicodeDecodeError: 'charmap' codec can't decode byte 0x8d in position 68: character maps to <undefined>

Pri ročnem definiranju kodiranja datoteke se vsebina naloži pravilno. Preverjeno le na Win okolju.