### PR TITLE
Number of samples as parameter for generate_data with data_type 'circle'

### DIFF
--- a/tests/svm-test.py
+++ b/tests/svm-test.py
@@ -18,7 +18,7 @@ def generate_data(data_type, n_samples=100):
             cluster_std=0.4
         )
     elif data_type == "circle":
-        X = (np.random.rand(500, 2) - 0.5) * 20
+        X = (np.random.rand(n_samples, 2) - 0.5) * 20
         y = (np.sqrt(np.sum(X ** 2, axis=1)) > 8).astype(int)
 
     X = add_ones(X)


### PR DESCRIPTION
Number of samples for `generate_data` with option `'circle'` is currently hard-coded to 500. This changes it to use `n_samples`. This was probably the intended functionality.